### PR TITLE
Configure GitHub Actions to run tests and ensure yarn.lock remains current

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,57 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+    # long-lived branches
+    - main
+
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  check-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - run: npm install -g yarn
+      - run: yarn install --ignore-scripts --frozen-lockfile --ignore-engines
+
+  run-tests:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+        node-version:
+          - 12.x
+          - 14.x
+        url:
+          - mainnet_https
+          # HACK no websockets cause it's causing tests to not exit
+          # - mainnet_wss
+        include:
+          - url: mainnet_https
+            url_secret: INFURA_MAINNET_HTTPS
+          # - url: mainnet_wss
+          #   url_secret: INFURA_MAINNET_WSS
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install -g yarn
+
+      - run: yarn
+
+      - run: yarn ci
+        env:
+          ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_KEY }}
+          MAINNET_URL: ${{ secrets[matrix.url_secret] }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "start": "ts-node-dev ./bin/serve.ts",
     "prepare": "tsc",
+    "ci": "CI=true yarn test --colors",
     "test": "jest"
   },
   "files": [


### PR DESCRIPTION
This PR adds two CI jobs:
- `check-lockfile`, which exits non-zero if a checkout + build would cause the lockfile to change (i.e., lockfile changes must be committed!)
- `run-tests`, which runs the tests in a combinatoric matrix of environment differences.

The tests currently require environment variables containing an Etherscan API key and a mainnet URL; I've created new API keys for both and added these as repository secrets. For Infura, I've added separate secrets for HTTPS and for Websockets, but `yarn test` seems to hang when connecting with websockets, so this PR thus configures CI to run only against HTTPS for now.